### PR TITLE
README: Clarify which projects are deprecated and which aren't.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-zsh-syntax-highlighting
-=======================
+Fork of zsh-syntax-highlighting
+===============================
 
-<red>**THIS PROJECT IS NO LONGER MAINTAINED.
-YOU MAY WANT TO TEST ITS SUCCESSOR: [chromatic-zsh](https://github.com/jimmijj/chromatic-zsh).**
+**THIS FORK IS NO LONGER MAINTAINED.
+YOU MAY WANT TO TEST ITS SUCCESSOR: [chromatic-zsh](https://github.com/jimmijj/chromatic-zsh)
+YOU MAY WANT TO TEST THE PARENT PROJECT: [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)**
 
 Enhanced highlighting of the [Zsh](http://www.zsh.org) command-line, including syntax, paths, files, selected regions, searched patterns and much more.
 


### PR DESCRIPTION
Dear @jimmijj,

I see you've deprecated your fork of zsh-syntax-highlighting and began an alternative project, chromatic-zsh, instead.  I'd like to ask you to merge the enclosed patch, so that anyone who stumbles across your z-sy-h fork isn't mislead to think that z-sy-h is deprecated, since it is not.

Good luck with your new project!  (And a great name you chose for it, too...)

Daniel
